### PR TITLE
Add FAILED payment status

### DIFF
--- a/venmo_api/models/payment.py
+++ b/venmo_api/models/payment.py
@@ -66,3 +66,4 @@ class PaymentStatus(Enum):
     SETTLED = 'settled'
     CANCELLED = 'cancelled'
     PENDING = 'pending'
+    FAILED = 'failed'


### PR DESCRIPTION
Add missing FAILED payment status to avoid exception
```
~/.virtualenvs/test3/lib/python3.7/site-packages/venmo_api/utils/api_util.py in deserialize(response, data_type, nested_response)
     41     # Return a list of <class> data_type
     42     if isinstance(data, list):
---> 43         return __get_objs_from_json_list(json_list=data, data_type=data_type)
     44
     45     return data_type.from_json(json=data)

~/.virtualenvs/test3/lib/python3.7/site-packages/venmo_api/utils/api_util.py in __get_objs_from_json_list(json_list, data_type)
     75     result = []
     76     for obj in json_list:
---> 77         data_obj = data_type.from_json(obj)
     78         if not data_obj:
     79             continue

~/.virtualenvs/test3/lib/python3.7/site-packages/venmo_api/models/payment.py in from_json(cls, json)
     59             date_completed=string_to_timestamp(parser.get_date_completed()),
     60             note=parser.get_note(),
---> 61             status=PaymentStatus(parser.get_status())
     62         )
     63
...
ValueError: 'failed' is not a valid PaymentStatus
```